### PR TITLE
Removed Wkhtmltopdf from workflow

### DIFF
--- a/.github/workflows/action-pytest.yml
+++ b/.github/workflows/action-pytest.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Get pytest and other requirements
         run: |
           sudo apt-get install python3
-          sudo apt-get install wkhtmltopdf
           pip install -r $GITHUB_WORKSPACE/requirements.txt
 
       - name: Run pytest


### PR DESCRIPTION
wkhtmltopdf is no longer used for pdf generation and should not be in the pytest workflow any longer.